### PR TITLE
Bump to v20.0

### DIFF
--- a/lib/facebook_ads/version.rb
+++ b/lib/facebook_ads/version.rb
@@ -19,6 +19,6 @@
 # FB:AUTOGEN
 
 module FacebookAds
-  VERSION = '17.0.1'
-  API_VERSION = '17.0'
+  VERSION = '20.0.0'
+  API_VERSION = '20.0'
 end


### PR DESCRIPTION
Facebook will deprecate v18 on [August 13th](https://developers.facebook.com/docs/marketing-api/marketing-api-changelog/versions). They've started auto-upgrading API calls but I wanted to review and upgrade it ourself to make sure we're ahead of any breaking changes.